### PR TITLE
Key and value are reversed for iOS events

### DIFF
--- a/src/app-center.ios.ts
+++ b/src/app-center.ios.ts
@@ -74,7 +74,7 @@ export class AppCenter {
             let _properties = NSMutableDictionary.alloc().init();
 
             properties.forEach(property => {
-                _properties.setValueForKey(property.key, property.value);
+                _properties.setValueForKey(property.value, property.key);
             });
 
             MSAnalytics.trackEventWithProperties(eventName, _properties);


### PR DESCRIPTION
See https://developer.apple.com/documentation/foundation/nsmutabledictionary/1416335-setvalue?language=objc. The first argument should be the value, the second the key.

In Android it does work as expected